### PR TITLE
Feature/mixins

### DIFF
--- a/standards/scss.md
+++ b/standards/scss.md
@@ -293,6 +293,8 @@ Provide default arguments when their absence could cause a compilation error, ot
 @mixin isVisuallyHidden() {
     width: 1px;
     height: 1px;
+    margin: -1px;
+    border: 0;
     position: absolute;
     left: -10000px;
     top: auto;

--- a/standards/scss.md
+++ b/standards/scss.md
@@ -293,11 +293,9 @@ Provide default arguments when their absence could cause a compilation error, ot
 @mixin isVisuallyHidden() {
     width: 1px;
     height: 1px;
-    margin: -1px;
-    padding: 0;
-    border: 0;
     position: absolute;
-    clip: rect(0 0 0 0);
+    left: -10000px;
+    top: auto;
     overflow: hidden;
 }
 ```


### PR DESCRIPTION
Since the clip property is being deprecated, we might want to update our examples to not use them in case others attempt to use this mixin example. I've updated to another method that doesn't require clip.
