### PR TITLE
Renamed SCSS source directory from `scss` to `styles` to be consistent.

### DIFF
--- a/standards/scss.md
+++ b/standards/scss.md
@@ -23,7 +23,7 @@ Additionally there is a `screen.scss` file that is used to import all SCSS parti
 
 ```diff
 └── assets
-    └── scss
+    └── styles
         ├── base
         |   ├── _elements.scss
         |   ├── _fonts.scss
@@ -69,7 +69,7 @@ Taking these steps provides two production ready CSS files - one of which requir
 
 ```diff
 └── assets
-    └── scss
+    └── styles
         ├── base
         |   ├── _elements.scss
         |   ├── _fonts.scss


### PR DESCRIPTION
The `assets/scss` directory is inconsistent with the [Files & Folders](https://github.com/thenerdery/html-css-standards/blob/master/standards/files-folders.md#files--folders) recommendations. This PR changes the SCSS standards to use `assets/styles` to be consistent.
